### PR TITLE
Style patch for v9.6.0

### DIFF
--- a/public/perilous_quest/styles.css
+++ b/public/perilous_quest/styles.css
@@ -1741,7 +1741,7 @@ svg {
   }
 
   #game_meter {
-    margin-left: 3%;
+    width: 100%;
   }
 
   #namediv {


### PR DESCRIPTION
Style patch for v9.6.0

Meter takes up 100% width instead of 90% on mobile